### PR TITLE
Fix: Create log and tmp directories in Dockerfile for Avo logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN bundle install
 # Copy application code
 COPY . .
 
+# Create necessary directories for Rails (log, tmp, storage) before switching user
+RUN mkdir -p log tmp/pids tmp/cache tmp/sockets tmp/storage storage && \
+    chmod -R 755 log tmp storage
+
 # Create a non-root user
 RUN useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
@@ -55,9 +59,10 @@ RUN bundle install --without development test && \
 # Copy application code
 COPY . .
 
-# Precompile assets (Propshaft handles this, but ensure public assets directory exists)
-RUN mkdir -p public/assets && \
-    chmod -R 755 public
+# Create necessary directories for Rails (log, tmp, storage) before switching user
+RUN mkdir -p log tmp/pids tmp/cache tmp/sockets tmp/storage storage && \
+    mkdir -p public/assets && \
+    chmod -R 755 public log tmp storage
 
 # Create a non-root user
 RUN useradd -m -u 1000 appuser && \


### PR DESCRIPTION
- Create log directory that Avo needs for avo.log file
- Create tmp directories (pids, cache, sockets, storage) for Rails
- Ensure proper permissions before switching to non-root user
- Fixes deployment error: No such file or directory @ rb_sysopen - /app/log/avo.log