### PR TITLE
Add apt package caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR adds caching for apt packages in the CI workflow to improve build performance.

## Changes
- Added  step to cache apt packages
- Cache key includes OS and Gemfile.lock hash for proper invalidation
- This complements the existing bundler cache for faster CI runs

The bundler cache was already configured via `ruby/setup-ruby@v1` with `bundler-cache: true`, which caches gems based on Gemfile.lock. This addition caches system packages to avoid re-downloading them on every run.