### PR TITLE
Route closed tickets to low-priority queues (comments_closed, metrics_closed)

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,7 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    - queues: ["default", "metrics", "comments", "metrics_closed", "comments_closed"]
       threads: <%= ENV.fetch("SOLID_QUEUE_THREADS", 3) %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1


### PR DESCRIPTION
## Summary

When the incremental ticket job processes tickets, comments and metrics fetch jobs for **closed** tickets are now enqueued to dedicated low-priority queues (`comments_closed`, `metrics_closed`) so that open-ticket work is processed first.

## Changes

- **IncrementalTicketJob**: Detects `status == "closed"` from ticket data and enqueues `FetchTicketCommentsJob` / `FetchTicketMetricsJob` with `queue: "comments_closed"` and `queue: "metrics_closed"` respectively. Open (or other) tickets continue to use the default `comments` and `metrics` queues.
- **config/queue.yml**: Replaced `queues: "*"` with an explicit ordered list `["default", "metrics", "comments", "metrics_closed", "comments_closed"]` so closed-ticket queues are polled last.
- **Tests**: Added test that closed tickets are enqueued to `comments_closed` and `metrics_closed`; extended existing test to assert open tickets use `comments` and `metrics` queues.

## Verification

- `bundle exec rails test` — 129 runs, 426 assertions, 0 failures
- `bin/standardrb --fix` — no issues