### PR TITLE
refactor: Add shared Zendesk API response helpers

### DIFF
--- a/app/jobs/concerns/zendesk_rate_limit_handler.rb
+++ b/app/jobs/concerns/zendesk_rate_limit_handler.rb
@@ -9,7 +9,7 @@ module ZendeskRateLimitHandler
 
     wait_seconds = desk.wait_till - current_time
     job_log(:info,
-            "[#{self.class.name}] Desk #{desk.domain} rate-limited, waiting #{wait_seconds}s (until #{Time.at(desk.wait_till)})")
+      "[#{self.class.name}] Desk #{desk.domain} rate-limited, waiting #{wait_seconds}s (until #{Time.at(desk.wait_till)})")
     sleep(wait_seconds) unless Rails.env.test?
     desk.reload
   end
@@ -21,14 +21,30 @@ module ZendeskRateLimitHandler
     info = log_rate_limit_headers(response_or_env, job_name)
     return unless info
 
-    headroom_percent = ENV.fetch('ZENDESK_RATE_LIMIT_HEADROOM_PERCENT', '20').to_i
+    headroom_percent = ENV.fetch("ZENDESK_RATE_LIMIT_HEADROOM_PERCENT", "20").to_i
     return unless info[:percentage] && info[:percentage] < headroom_percent
     return unless info[:reset]&.positive?
 
     wait_seconds = info[:reset] + 1
     job_log(:info,
-            "[#{job_name}] Rate limit low (#{info[:percentage]}% remaining, headroom #{headroom_percent}%), backing off #{wait_seconds}s until reset")
+      "[#{job_name}] Rate limit low (#{info[:percentage]}% remaining, headroom #{headroom_percent}%), backing off #{wait_seconds}s until reset")
     sleep(wait_seconds) unless Rails.env.test?
+  end
+
+  # Returns HTTP status from a Faraday response or env hash (e.g. 200, 429).
+  def extract_response_status(response)
+    return nil unless response
+    return response.status if response.respond_to?(:status)
+    return response[:status] if response.is_a?(Hash)
+    (response.respond_to?(:env) && response.env) ? response.env[:status] : nil
+  end
+
+  # Returns parsed response body as a Hash (handles already-parsed body or JSON string).
+  def parse_response_body(response)
+    return {} unless response&.respond_to?(:body)
+    body = response.body
+    return {} if body.nil?
+    body.is_a?(Hash) ? body : JSON.parse(body.to_s)
   end
 
   private
@@ -44,8 +60,8 @@ module ZendeskRateLimitHandler
     # Standard rate limit headers
     rate_limit = extract_header_value(headers, %w[X-Rate-Limit x-rate-limit ratelimit-limit])
     rate_limit_remaining = extract_header_value(headers,
-                                                %w[X-Rate-Limit-Remaining x-rate-limit-remaining ratelimit-remaining])
-    rate_limit_reset = extract_header_value(headers, ['ratelimit-reset'])
+      %w[X-Rate-Limit-Remaining x-rate-limit-remaining ratelimit-remaining])
+    rate_limit_reset = extract_header_value(headers, ["ratelimit-reset"])
 
     return unless rate_limit && rate_limit_remaining
 
@@ -57,8 +73,8 @@ module ZendeskRateLimitHandler
     rate_limit_msg = "[#{job_name}] X-Rate-Limit: #{rate_limit}, X-Rate-Limit-Remaining: #{rate_limit_remaining} (#{percentage_remaining}%)"
     rate_limit_msg += " (resets in #{rate_limit_reset}s)" if rate_limit_reset
 
-    headroom_percent = ENV.fetch('ZENDESK_RATE_LIMIT_HEADROOM_PERCENT', '20').to_i
-    level = percentage_remaining < (headroom_percent / 2) ? :warn : :info
+    headroom_percent = ENV.fetch("ZENDESK_RATE_LIMIT_HEADROOM_PERCENT", "20").to_i
+    level = (percentage_remaining < (headroom_percent / 2)) ? :warn : :info
     job_log(level, rate_limit_msg)
 
     # Return rate limit info for potential dynamic throttling
@@ -126,7 +142,7 @@ module ZendeskRateLimitHandler
     return error.instance_variable_get(:@response) if error.instance_variable_defined?(:@response)
 
     # Check if error message indicates 429
-    if error.message.include?('status 429')
+    if error.message.include?("status 429")
       # Try to extract from env if available (ZendeskAPI callback style)
       return error.env if error.respond_to?(:env) && error.env
 

--- a/app/jobs/fetch_ticket_comments_job.rb
+++ b/app/jobs/fetch_ticket_comments_job.rb
@@ -11,15 +11,15 @@ class FetchTicketCommentsJob < FetchTicketDetailJobBase
   end
 
   def response_key
-    'comments'
+    "comments"
   end
 
   def resource_name
-    'comments'
+    "comments"
   end
 
   def delay_env_var
-    'COMMENT_JOB_DELAY_SECONDS'
+    "COMMENT_JOB_DELAY_SECONDS"
   end
 
   def empty_value
@@ -31,7 +31,7 @@ class FetchTicketCommentsJob < FetchTicketDetailJobBase
   end
 
   def persist_data(ticket, data)
-    updated_raw_data = ticket.raw_data.merge('comments' => data)
+    updated_raw_data = ticket.raw_data.merge("comments" => data)
     ticket.update_columns(raw_data: updated_raw_data)
   end
 end

--- a/app/jobs/fetch_ticket_detail_job_base.rb
+++ b/app/jobs/fetch_ticket_detail_job_base.rb
@@ -28,11 +28,11 @@ class FetchTicketDetailJobBase < ApplicationJob
   end
 
   def apply_throttle(ticket_id, desk)
-    sleep_duration = ENV.fetch(delay_env_var, '0.5').to_f
+    sleep_duration = ENV.fetch(delay_env_var, "0.5").to_f
     return unless sleep_duration > 0
 
     job_log(:info,
-            "[#{job_name}] Applying throttle delay: #{sleep_duration}s before API call for ticket #{ticket_id} (desk: #{desk.domain})")
+      "[#{job_name}] Applying throttle delay: #{sleep_duration}s before API call for ticket #{ticket_id} (desk: #{desk.domain})")
     sleep(sleep_duration)
   end
 
@@ -42,12 +42,12 @@ class FetchTicketDetailJobBase < ApplicationJob
 
     begin
       job_log(:info,
-              "[#{job_name}] Fetching #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain}, retry: #{retry_count}/#{MAX_RETRIES})")
+        "[#{job_name}] Fetching #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain}, retry: #{retry_count}/#{MAX_RETRIES})")
 
       response = client.connection.get(api_path(ticket_id))
       throttle_using_rate_limit_headers(response.respond_to?(:env) ? response.env : response)
 
-      response_status = response.respond_to?(:status) ? response.status : response.env&.dig(:status)
+      response_status = extract_response_status(response)
       if response_status == 429
         job_log(:warn, "[#{job_name}] ⚠️  Rate limit (429) received for ticket #{ticket_id} (desk: #{desk.domain})")
         env = response.respond_to?(:env) ? response.env : response
@@ -56,51 +56,51 @@ class FetchTicketDetailJobBase < ApplicationJob
 
         if retry_count > MAX_RETRIES
           job_log(:warn,
-                  "[#{job_name}] ✗ Max retries reached for ticket #{ticket_id} (desk: #{desk.domain}), skipping #{resource_name}")
+            "[#{job_name}] ✗ Max retries reached for ticket #{ticket_id} (desk: #{desk.domain}), skipping #{resource_name}")
           return
         end
 
         job_log(:info, "[#{job_name}] Retrying ticket #{ticket_id} (attempt #{retry_count + 1}/#{MAX_RETRIES + 1})")
-        raise 'Rate limit exceeded (429), retrying'
+        raise "Rate limit exceeded (429), retrying"
       end
 
-      response_body = response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
+      response_body = parse_response_body(response)
       data = response_body[response_key] || empty_value
 
       if data.any?
         log_received(ticket_id, data)
         persist_data(ticket, data)
         job_log(:info,
-                "[#{job_name}] ✓ Successfully stored #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain})")
+          "[#{job_name}] ✓ Successfully stored #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain})")
       else
         job_log(:info, "[#{job_name}] No #{resource_name} found for ticket #{ticket_id} (desk: #{desk.domain})")
       end
-    rescue StandardError => e
+    rescue => e
       # Re-raise from 429 response path – we already handled it, just retry the begin block
-      retry if e.message == 'Rate limit exceeded (429), retrying'
+      retry if e.message == "Rate limit exceeded (429), retrying"
 
-      is_rate_limit = e.message.include?('status 429') || e.message.include?('429') || e.message.include?('Rate limit exceeded')
+      is_rate_limit = e.message.include?("status 429") || e.message.include?("429") || e.message.include?("Rate limit exceeded")
 
       if is_rate_limit
         job_log(:warn,
-                "[#{job_name}] ⚠️  Rate limit error caught for ticket #{ticket_id} (desk: #{desk.domain}): #{e.message}")
+          "[#{job_name}] ⚠️  Rate limit error caught for ticket #{ticket_id} (desk: #{desk.domain}): #{e.message}")
         response_from_error = extract_response_from_error(e)
         handle_rate_limit_error(response_from_error || e, desk, ticket_id, retry_count, MAX_RETRIES)
         retry_count += 1
 
         if retry_count <= MAX_RETRIES
           job_log(:info,
-                  "[#{job_name}] Retrying ticket #{ticket_id} after rate limit (attempt #{retry_count + 1}/#{MAX_RETRIES + 1})")
+            "[#{job_name}] Retrying ticket #{ticket_id} after rate limit (attempt #{retry_count + 1}/#{MAX_RETRIES + 1})")
           retry
         else
           job_log(:warn,
-                  "[#{job_name}] ✗ Max retries reached for ticket #{ticket_id} (desk: #{desk.domain}) after rate limit, skipping #{resource_name}")
+            "[#{job_name}] ✗ Max retries reached for ticket #{ticket_id} (desk: #{desk.domain}) after rate limit, skipping #{resource_name}")
           return
         end
       end
 
       job_log(:warn,
-              "[#{job_name}] ✗ Error fetching #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain}): #{e.class}: #{e.message}")
+        "[#{job_name}] ✗ Error fetching #{resource_name} for ticket #{ticket_id} (desk: #{desk.domain}): #{e.class}: #{e.message}")
       Rails.logger.debug("[#{job_name}] Backtrace: #{e.backtrace&.first(3)&.join("\n")}")
     end
   end

--- a/app/jobs/fetch_ticket_metrics_job.rb
+++ b/app/jobs/fetch_ticket_metrics_job.rb
@@ -11,19 +11,19 @@ class FetchTicketMetricsJob < FetchTicketDetailJobBase
   end
 
   def response_key
-    'ticket_metric'
+    "ticket_metric"
   end
 
   def resource_name
-    'metrics'
+    "metrics"
   end
 
   def delay_env_var
-    'METRICS_JOB_DELAY_SECONDS'
+    "METRICS_JOB_DELAY_SECONDS"
   end
 
   def log_received(ticket_id, data)
-    keys = data.keys.join(', ')
+    keys = data.keys.join(", ")
     job_log(:info, "[#{job_name}] Received metrics data for ticket #{ticket_id}: #{keys}")
   end
 
@@ -44,7 +44,7 @@ class FetchTicketMetricsJob < FetchTicketDetailJobBase
     extracted_metrics << "replies: #{ticket.replies}" if ticket.replies
     if extracted_metrics.any?
       job_log(:info,
-              "[#{job_name}] Extracted metrics for ticket #{ticket.zendesk_id}: #{extracted_metrics.join(', ')}")
+        "[#{job_name}] Extracted metrics for ticket #{ticket.zendesk_id}: #{extracted_metrics.join(", ")}")
     end
 
     ticket.save!

--- a/test/jobs/concerns/zendesk_rate_limit_handler_test.rb
+++ b/test/jobs/concerns/zendesk_rate_limit_handler_test.rb
@@ -46,6 +46,59 @@ class ZendeskRateLimitHandlerTest < ActiveJob::TestCase
     assert @desk.wait_till <= expected_max, "wait_till should reflect Retry-After 15 + retry 1"
   end
 
+  test "extract_response_status returns status from response object" do
+    response = Object.new
+    response.define_singleton_method(:status) { 429 }
+    job = DummyRateLimitJob.new
+    assert_equal 429, job.send(:extract_response_status, response)
+  end
+
+  test "extract_response_status returns status from response.env when response has no status method" do
+    env = {status: 200}
+    response = Object.new
+    response.define_singleton_method(:env) { env }
+    response.define_singleton_method(:respond_to?) { |m| m == :env || (super(m) if defined?(super)) }
+    job = DummyRateLimitJob.new
+    assert_equal 200, job.send(:extract_response_status, response)
+  end
+
+  test "extract_response_status returns status from Hash (env)" do
+    job = DummyRateLimitJob.new
+    assert_equal 429, job.send(:extract_response_status, {status: 429})
+  end
+
+  test "extract_response_status returns nil for nil or missing status" do
+    job = DummyRateLimitJob.new
+    assert_nil job.send(:extract_response_status, nil)
+    assert_nil job.send(:extract_response_status, {})
+  end
+
+  test "parse_response_body returns Hash when body is already a Hash" do
+    body = {"tickets" => []}
+    response = Object.new
+    response.define_singleton_method(:body) { body }
+    response.define_singleton_method(:respond_to?) { |m| m == :body || (super(m) if defined?(super)) }
+    job = DummyRateLimitJob.new
+    assert_equal body, job.send(:parse_response_body, response)
+  end
+
+  test "parse_response_body parses JSON string" do
+    response = Object.new
+    response.define_singleton_method(:body) { '{"key":"value"}' }
+    response.define_singleton_method(:respond_to?) { |m| m == :body || (super(m) if defined?(super)) }
+    job = DummyRateLimitJob.new
+    assert_equal({"key" => "value"}, job.send(:parse_response_body, response))
+  end
+
+  test "parse_response_body returns empty Hash for nil response or nil body" do
+    job = DummyRateLimitJob.new
+    assert_equal({}, job.send(:parse_response_body, nil))
+    response = Object.new
+    response.define_singleton_method(:body) { nil }
+    response.define_singleton_method(:respond_to?) { |m| m == :body || (super(m) if defined?(super)) }
+    assert_equal({}, job.send(:parse_response_body, response))
+  end
+
   test "does not log Retry-After header not found when header is present in Faraday exception" do
     faraday_error = build_faraday_error_with_retry_after(42)
     warn_messages = []


### PR DESCRIPTION
## Summary

Extract shared response parsing and status extraction logic used by jobs that call the Zendesk API (closes #75).

## Changes

- **ZendeskRateLimitHandler**
  - `extract_response_status(response)` – returns HTTP status from Faraday response or env hash (unifies Base vs Incremental variants).
  - `parse_response_body(response)` – returns parsed body as a Hash (handles already-parsed body or JSON string; returns `{}` for nil).
- **FetchTicketDetailJobBase** – uses `extract_response_status` and `parse_response_body` instead of inline logic.
- **IncrementalTicketJob** – uses `extract_response_status` and `parse_response_body` instead of inline logic.
- **Tests** – unit tests for both helpers in `zendesk_rate_limit_handler_test.rb`.
- **Lint** – standardrb fixes (double-quote style) in `fetch_ticket_comments_job.rb` and `fetch_ticket_metrics_job.rb`.

## Verification

- `bundle exec rake test` – 136 runs, 435 assertions, 0 failures.
- `bin/standardrb --fix` – clean.