### PR TITLE
Webhooks tickets: require body for put/post, GET via perform_now with response

### DIFF
--- a/app/jobs/zendesk_proxy_job.rb
+++ b/app/jobs/zendesk_proxy_job.rb
@@ -45,6 +45,7 @@ class ZendeskProxyJob < ApplicationJob
 
       # Proxy completed; we don't persist to ZendeskTicket
       Rails.logger.info "[ZendeskProxyJob] #{method.upcase} #{path} completed with status #{status}"
+      [status, parse_response_body(response)] if method.to_s.downcase == "get"
     rescue => e
       retry if e.message == "Rate limit exceeded (429), retrying"
 

--- a/test/jobs/zendesk_proxy_job_test.rb
+++ b/test/jobs/zendesk_proxy_job_test.rb
@@ -33,11 +33,14 @@ class ZendeskProxyJobTest < ActiveJob::TestCase
       .to_return(status: status, body: {ticket: {id: ticket_id}}.to_json, headers: {"Content-Type" => "application/json"})
   end
 
-  test "GET ticket proxies to Zendesk and does not create ZendeskTicket" do
+  test "GET ticket proxies to Zendesk, returns status and body, and does not create ZendeskTicket" do
     stub_ticket_get(3001, {id: 3001, subject: "Proxy get", status: "open"})
 
     assert_no_difference "ZendeskTicket.count" do
-      ZendeskProxyJob.perform_now("support.example.com", "get", 3001, nil)
+      result = ZendeskProxyJob.perform_now("support.example.com", "get", 3001, nil)
+      assert_equal 200, result[0]
+      assert_equal 3001, result[1]["ticket"]["id"]
+      assert_equal "Proxy get", result[1]["ticket"]["subject"]
     end
   end
 


### PR DESCRIPTION
## Summary
- **Body required for PUT/POST**: Validates that `body` is present for `put` and `post`; returns 422 with `body is required for put/post` when missing.
- **GET via perform_now**: GET requests run through `ZendeskProxyJob.perform_now` and return the Zendesk response (status + JSON body) so callers (e.g. n8n) get the ticket data in the same request. PUT/POST still use `perform_later` and return 202 Accepted.
- **ZendeskProxyJob**: Returns `[status, parse_response_body(response)]` for GET so the controller can proxy the response.

## Tests
- Body validation: PUT/post without body → 422.
- GET: 200 + ticket body (WebMock stub); job test asserts returned `[status, body]`.
- get/put no ticket_id test updated so PUT case includes body.

Tests and `bin/standardrb --fix` pass.