### PR TITLE
Fix MigrateTicketCommentsJob test for Minitest 6 / Rails 8

### DIFF
--- a/test/jobs/migrate_ticket_comments_job_test.rb
+++ b/test/jobs/migrate_ticket_comments_job_test.rb
@@ -111,11 +111,21 @@ class MigrateTicketCommentsJobTest < ActiveJob::TestCase
   end
 
   test "re-enqueues failed tickets separately and still advances last_id" do
-    ZendeskTicketComment.stub(:upsert_all, ->(*) { raise ActiveRecord::StatementInvalid, "simulated DB error" }) do
-      assert_enqueued_with(job: MigrateTicketCommentsJob, kwargs: {retry_ids: [@ticket.id]}) do
-        MigrateTicketCommentsJob.perform_now
-      end
+    ZendeskTicketComment.define_singleton_method(:upsert_all) do |*, **|
+      raise ActiveRecord::StatementInvalid, "simulated DB error"
     end
+    assert_enqueued_with(
+      job: MigrateTicketCommentsJob,
+      args: lambda { |job_args|
+        h = job_args&.first
+        h = h.with_indifferent_access if h.is_a?(Hash)
+        h && h[:retry_ids] == [@ticket.id]
+      }
+    ) do
+      MigrateTicketCommentsJob.perform_now
+    end
+  ensure
+    ZendeskTicketComment.singleton_class.remove_method(:upsert_all)
   end
 
   test "retry_ids mode re-attempts only specified tickets" do


### PR DESCRIPTION
## Summary
- **Minitest 6** dropped `minitest/mock`, so `ZendeskTicketComment.stub` raised `NoMethodError`. The test now temporarily overrides `upsert_all` on the model singleton class and removes it in `ensure`.
- **Rails 8** `assert_enqueued_with` does not accept `kwargs:`; use an `args:` proc to assert `retry_ids` on the enqueued job.

## Verification
- `bundle exec rails test` (232 runs, 0 failures)
- `bin/standardrb test/jobs/migrate_ticket_comments_job_test.rb`

No JS package in repo — yarn lint/build skipped.