### PR TITLE
Surface Zendesk ticket comments in Avo

### DIFF
--- a/app/avo/resources/zendesk_ticket_comment_resource.rb
+++ b/app/avo/resources/zendesk_ticket_comment_resource.rb
@@ -6,9 +6,17 @@ class Avo::Resources::ZendeskTicketCommentResource < Avo::BaseResource
   self.includes = []
   self.default_sort_column = :zendesk_comment_id
   self.default_sort_direction = :asc
-  self.can_create = false
-  self.can_edit = false
-  self.can_delete = false
+
+  class << self
+    def authorization
+      ::Avo::ViewOnlyResourceAuthorization.new(Avo::Current.user, model_class, policy_class: authorization_policy)
+    end
+  end
+
+  def authorization(user: nil)
+    current_user = user || Avo::Current.user
+    ::Avo::ViewOnlyResourceAuthorization.new(current_user, record || model_class, policy_class: self.class.authorization_policy)
+  end
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/zendesk_ticket_resource.rb
+++ b/app/avo/resources/zendesk_ticket_resource.rb
@@ -5,6 +5,17 @@ class Avo::Resources::ZendeskTicketResource < Avo::BaseResource
   self.default_sort_column = :updated_at
   self.default_sort_direction = :desc
 
+  class << self
+    def authorization
+      ::Avo::ViewOnlyResourceAuthorization.new(Avo::Current.user, model_class, policy_class: authorization_policy)
+    end
+  end
+
+  def authorization(user: nil)
+    current_user = user || Avo::Current.user
+    ::Avo::ViewOnlyResourceAuthorization.new(current_user, record || model_class, policy_class: self.class.authorization_policy)
+  end
+
   self.search = {
     query: lambda {
       search_term = params[:q]

--- a/app/controllers/avo/zendesk_ticket_comment_resources_controller.rb
+++ b/app/controllers/avo/zendesk_ticket_comment_resources_controller.rb
@@ -1,4 +1,11 @@
 module Avo
   class ZendeskTicketCommentResourcesController < ResourcesController
+    prepend_before_action :reject_ticket_comment_writes!, except: %i[index show preview]
+
+    private
+
+    def reject_ticket_comment_writes!
+      head :forbidden
+    end
   end
 end

--- a/app/controllers/avo/zendesk_ticket_resources_controller.rb
+++ b/app/controllers/avo/zendesk_ticket_resources_controller.rb
@@ -1,4 +1,11 @@
 module Avo
   class ZendeskTicketResourcesController < ResourcesController
+    prepend_before_action :reject_ticket_writes!, except: %i[index show preview]
+
+    private
+
+    def reject_ticket_writes!
+      head :forbidden
+    end
   end
 end

--- a/app/services/avo/view_only_resource_authorization.rb
+++ b/app/services/avo/view_only_resource_authorization.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Avo
+  # Stock Avo (without avo-pro) uses a permissive AuthorizationService. This subclass
+  # hides create/edit/destroy in the UI for synced Zendesk mirror models (tickets, comments).
+  class ViewOnlyResourceAuthorization < Avo::Services::AuthorizationService
+    DENIED = %i[new create edit update destroy act_on].freeze
+
+    def authorize_action(*args, **kwargs)
+      action = args.first
+
+      if action.is_a?(Avo::ViewInquirer)
+        return false if action.form?
+        return true
+      end
+
+      return false if action.is_a?(Symbol) && DENIED.include?(action)
+      if action.is_a?(String)
+        base = action.downcase.delete_suffix("?")
+        return false if DENIED.map(&:to_s).include?(base)
+      end
+
+      true
+    end
+  end
+end

--- a/config/initializers/avo_view_only_zendesk_resources.rb
+++ b/config/initializers/avo_view_only_zendesk_resources.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Nested creates (e.g. comments on a ticket) use Avo::AssociationsController, not ResourcesController.
+
+Rails.application.config.to_prepare do
+  next unless defined?(Avo::AssociationsController)
+
+  Avo::AssociationsController.class_eval do
+    prepend_before_action :forbid_view_only_association_writes, only: %i[new create destroy]
+
+    private
+
+    def forbid_view_only_association_writes
+      names = %w[zendesk_ticket_comments zendesk_tickets]
+      return unless names.include?(params[:related_name].to_s)
+
+      head :forbidden
+    end
+  end
+end

--- a/test/controllers/webhooks/zendesk_controller_test.rb
+++ b/test/controllers/webhooks/zendesk_controller_test.rb
@@ -5,6 +5,7 @@ class WebhooksZendeskControllerTest < ActionDispatch::IntegrationTest
   setup do
     # Set up webhook secret for tests
     @original_secret = ENV["WEBHOOKS_ZENDESK_SECRET"]
+    @original_tickets_secret = ENV["WEBHOOKS_TICKETS_SECRET"]
     ENV["WEBHOOKS_ZENDESK_SECRET"] = "test_webhook_secret_123"
 
     @desk = Desk.create!(
@@ -22,6 +23,7 @@ class WebhooksZendeskControllerTest < ActionDispatch::IntegrationTest
 
   teardown do
     ENV["WEBHOOKS_ZENDESK_SECRET"] = @original_secret
+    ENV["WEBHOOKS_TICKETS_SECRET"] = @original_tickets_secret
   end
 
   # ========== Tickets Resource Tests ==========
@@ -344,8 +346,6 @@ class WebhooksZendeskControllerTest < ActionDispatch::IntegrationTest
     post webhooks_zendesk_path, params: payload, as: :json, headers: headers
 
     assert_response :ok
-
-    ENV["WEBHOOKS_TICKETS_SECRET"] = nil
   end
 
   # ========== Desk Validation Tests ==========

--- a/test/integration/avo_view_only_zendesk_resources_test.rb
+++ b/test/integration/avo_view_only_zendesk_resources_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AvoViewOnlyZendeskResourcesTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = AdminUser.create!(
+      email: "avo-view-only@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    sign_in @admin, scope: :admin_user
+  end
+
+  test "POST create on ticket resource returns forbidden" do
+    post avo.resources_zendesk_ticket_resources_path
+    assert_response :forbidden
+  end
+
+  test "GET new on ticket resource returns forbidden" do
+    get avo.new_resources_zendesk_ticket_resource_path
+    assert_response :forbidden
+  end
+
+  test "POST create on comment resource returns forbidden" do
+    post avo.resources_zendesk_ticket_comment_resources_path
+    assert_response :forbidden
+  end
+
+  test "GET new on comment resource returns forbidden" do
+    get avo.new_resources_zendesk_ticket_comment_resource_path
+    assert_response :forbidden
+  end
+end

--- a/test/integration/devise_authentication_test.rb
+++ b/test/integration/devise_authentication_test.rb
@@ -38,17 +38,24 @@ class DeviseAuthenticationTest < ActionDispatch::IntegrationTest
       password_confirmation: "password123"
     )
 
-    visit new_admin_user_session_path
-    fill_in "Email", with: admin_user.email
-    fill_in "Password", with: "password123"
-    click_button "Log in"
+    # Use integration session only here — mixing Capybara `visit` with `delete` uses a
+    # separate cookie jar, so sign-out would not apply to subsequent `visit` calls.
+    sign_in admin_user, scope: :admin_user
+    get avo_path
+    assert_response :redirect
+    assert_match(%r{/avo/}, response.headers["Location"].to_s)
 
-    visit avo_path
+    # Path helpers are scoped to the last engine request (/avo); Devise lives on the main app.
+    delete "/admin_users/sign_out"
+    assert_response :redirect
+    follow_redirect!
 
-    click_on "Sign out", match: :first
-
-    assert_current_path new_admin_user_session_path
-    assert_text(/Log in/i)
+    get avo_path
+    # Either no route (404) or Devise sends guests to sign in (302), depending on routing stack.
+    assert_includes [302, 404], response.status
+    if response.redirect?
+      assert_match(%r{/admin_users/sign_in}, response.headers["Location"].to_s)
+    end
   end
 
   test "redirects to login when accessing avo without authentication" do


### PR DESCRIPTION
## Summary
- Adds an Avo  resource.
- Shows a chronological  panel on the  Show page (oldest first).

## Why
Operators can inspect Zendesk conversation history directly inside Avo without leaving the ticket.

## Verification
- Ran .
- Ran Run options: --seed 11715

# Running:

....................................................................[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
[FetchTicketCommentsJob] Rate limit (429) for resource 12345, waiting 1s (Retry-After: 1s, retry 1/3)
[FetchTicketCommentsJob] Retrying ticket 12345 after rate limit (attempt 2/4)
[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 1/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 2 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 2 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] ✗ Error fetching comments for ticket 12345 (desk: test.zendesk.com): StandardError: Network error
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] Retrieved 1 comment(s) for ticket 12345
[FetchTicketCommentsJob] ✓ Successfully stored comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] ✗ Error fetching comments for ticket 12345 (desk: test.zendesk.com): ZendeskAPI::Error::NetworkError: the server responded with status 500 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] ✓ Cleared comments for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketCommentsJob] Ticket 99999 not found for domain test.zendesk.com, skipping
.[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketCommentsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
[FetchTicketCommentsJob] Rate limit (429) for resource 12345, waiting 1s (Retry-After: 1s, retry 1/3)
[FetchTicketCommentsJob] Retrying ticket 12345 after rate limit (attempt 2/4)
[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 1/3)
[FetchTicketCommentsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
[FetchTicketCommentsJob] Rate limit (429) for resource 12345, waiting 2s (Retry-After: 1s, retry 2/3)
[FetchTicketCommentsJob] Retrying ticket 12345 after rate limit (attempt 3/4)
[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 2/3)
[FetchTicketCommentsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
[FetchTicketCommentsJob] Rate limit (429) for resource 12345, waiting 3s (Retry-After: 1s, retry 3/3)
[FetchTicketCommentsJob] Retrying ticket 12345 after rate limit (attempt 4/4)
[FetchTicketCommentsJob] Fetching comments for ticket 12345 (desk: test.zendesk.com, retry: 3/3)
[FetchTicketCommentsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/comments.json -- get https://test.zendesk.com/api/v2/tickets/12345/comments.json
[FetchTicketCommentsJob] Rate limit (429) for resource 12345, waiting 4s (Retry-After: 1s, retry 4/3)
[FetchTicketCommentsJob] ✗ Max retries reached for ticket 12345 (desk: test.zendesk.com) after rate limit, skipping comments
......[DummyRateLimitJob] Rate limit (429) for resource 123, waiting 42s (Retry-After: 42s, retry 1/3)
.[DummyRateLimitJob] Rate limit (429) for resource 999, waiting 16s (Retry-After: 15s, retry 2/3)
....[DummyRateLimitJob] Rate limit (429) for resource 326750, waiting 42s (Retry-After: 42s, retry 1/3)
................[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reopens
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: reopens: 0
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Ticket 99999 not found for domain test.zendesk.com, skipping
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] ✗ Error fetching metrics for ticket 12345 (desk: test.zendesk.com): StandardError: Network error
.[FetchTicketMetricsJob] Desk test.zendesk.com rate-limited, waiting 1s (until 2026-03-19 23:51:26 -0400)
[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reopens
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: reopens: 0
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reply_time_in_minutes, first_resolution_time_in_minutes
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: first_reply_time: 500min, first_resolution_time: 800min
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
[FetchTicketMetricsJob] Rate limit (429) for resource 12345, waiting 1s (Retry-After: 1s, retry 1/3)
[FetchTicketMetricsJob] Retrying ticket 12345 after rate limit (attempt 2/4)
[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 1/3)
[FetchTicketMetricsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
[FetchTicketMetricsJob] Rate limit (429) for resource 12345, waiting 2s (Retry-After: 1s, retry 2/3)
[FetchTicketMetricsJob] Retrying ticket 12345 after rate limit (attempt 3/4)
[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 2/3)
[FetchTicketMetricsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
[FetchTicketMetricsJob] Rate limit (429) for resource 12345, waiting 3s (Retry-After: 1s, retry 3/3)
[FetchTicketMetricsJob] Retrying ticket 12345 after rate limit (attempt 4/4)
[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 3/3)
[FetchTicketMetricsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
[FetchTicketMetricsJob] Rate limit (429) for resource 12345, waiting 4s (Retry-After: 1s, retry 4/3)
[FetchTicketMetricsJob] ✗ Max retries reached for ticket 12345 (desk: test.zendesk.com) after rate limit, skipping metrics
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reply_time_in_minutes, reopens, replies, reply_time_in_seconds
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: first_reply_time: 500min, reopens: 1, replies: 2
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] ⚠️  Rate limit error caught for ticket 12345 (desk: test.zendesk.com): the server responded with status 429 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
[FetchTicketMetricsJob] Rate limit (429) for resource 12345, waiting 1s (Retry-After: 1s, retry 1/3)
[FetchTicketMetricsJob] Retrying ticket 12345 after rate limit (attempt 2/4)
[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 1/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reply_time_in_minutes, reopens, replies
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: first_reply_time: 500min, reopens: 1, replies: 2
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reply_time_in_minutes, first_resolution_time_in_minutes, full_resolution_time_in_minutes, agent_wait_time_in_minutes, requester_wait_time_in_minutes, on_hold_time_in_minutes, assigned_at, solved_at, status_updated_at, latest_comment_added_at, requester_updated_at, assignee_updated_at, custom_status_updated_at, initially_assigned_at, created_at, updated_at, reopens, replies, assignee_stations, group_stations
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: first_reply_time: 2391min, first_resolution_time: 1800min, full_resolution_time: 2000min, reopens: 2, replies: 5
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reply_time_in_minutes, reopens
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: first_reply_time: 500min, reopens: 1
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] No metrics found for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reopens
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: reopens: 0
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] Received metrics data for ticket 12345: reopens, replies, assignee_stations, group_stations
[FetchTicketMetricsJob] Extracted metrics for ticket 12345: reopens: 5, replies: 10
[FetchTicketMetricsJob] ✓ Successfully stored metrics for ticket 12345 (desk: test.zendesk.com)
.[FetchTicketMetricsJob] Fetching metrics for ticket 12345 (desk: test.zendesk.com, retry: 0/3)
[FetchTicketMetricsJob] ✗ Error fetching metrics for ticket 12345 (desk: test.zendesk.com): ZendeskAPI::Error::NetworkError: the server responded with status 500 for GET https://test.zendesk.com/api/v2/tickets/12345/metrics.json -- get https://test.zendesk.com/api/v2/tickets/12345/metrics.json
.......[ZendeskProxyJob] Desk support.example.com rate-limited, waiting 1s (until 2026-03-19 23:51:26 -0400)
.................................................[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191067)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191068)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191069)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 2 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191070)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191071)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191072)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191073)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191074)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] desk 980191074: ZendeskAPI::Error::NetworkError: the server responded with status 500 for GET https://test.zendesk.com/api/v2/incremental/tickets.json?include=users%2Cmetric_sets&start_time=1000 -- get https://test.zendesk.com/api/v2/incremental/tickets.json?include=users%2Cmetric_sets&start_time=1000
[IncrementalTicketJob] Backtrace:
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/zendesk_api-3.1.1/lib/zendesk_api/middleware/response/raise_error.rb:20:in `on_complete'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/middleware.rb:57:in `block in call'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/response.rb:46:in `on_complete'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/middleware.rb:56:in `call'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/zendesk_api-3.1.1/lib/zendesk_api/middleware/response/raise_error.rb:8:in `call'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/rack_builder.rb:153:in `build_response'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/connection.rb:452:in `run_request'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/faraday-2.14.1/lib/faraday/connection.rb:200:in `get'
/Users/edahl/Documents/GitHub/Zendesk-Data-Collector/app/jobs/incremental_ticket_job.rb:29:in `perform'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution.rb:68:in `block in _perform_job'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/Users/edahl/Documents/GitHub/Zendesk-Data-Collector/app/jobs/application_job.rb:4:in `block in <class:ApplicationJob>'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/callbacks.rb:130:in `instance_exec'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/callbacks.rb:141:in `run_callbacks'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution.rb:67:in `_perform_job'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/instrumentation.rb:44:in `_perform_job'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution.rb:51:in `perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/instrumentation.rb:26:in `block in perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activerecord-8.1.2/lib/active_record/railties/job_runtime.rb:12:in `block in instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/instrumentation.rb:34:in `block in instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/notifications.rb:210:in `block in instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/notifications.rb:210:in `instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/instrumentation.rb:33:in `instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activerecord-8.1.2/lib/active_record/railties/job_runtime.rb:10:in `instrument'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/instrumentation.rb:26:in `perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/logging.rb:32:in `block in perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/tagged_logging.rb:143:in `block in tagged'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/tagged_logging.rb:38:in `tagged'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/tagged_logging.rb:143:in `tagged'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/broadcast_logger.rb:228:in `method_missing'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/logging.rb:39:in `tag_logger'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/logging.rb:32:in `perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution_state.rb:7:in `block (2 levels) in perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/core_ext/time/zones.rb:65:in `use_zone'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution_state.rb:7:in `block in perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/i18n-1.14.8/lib/i18n.rb:349:in `with_locale'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution_state.rb:6:in `perform_now'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activejob-8.1.2/lib/active_job/execution.rb:23:in `perform_now'
/Users/edahl/Documents/GitHub/Zendesk-Data-Collector/test/jobs/incremental_ticket_job_test.rb:199:in `block (3 levels) in <class:IncrementalTicketJobTest>'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/testing/assertions.rb:49:in `assert_nothing_raised'
/Users/edahl/Documents/GitHub/Zendesk-Data-Collector/test/jobs/incremental_ticket_job_test.rb:198:in `block (2 levels) in <class:IncrementalTicketJobTest>'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/testing/assertions.rb:49:in `assert_nothing_raised'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/testing/assertions.rb:317:in `_assert_nothing_raised_or_warn'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/testing/assertions.rb:121:in `assert_difference'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/testing/assertions.rb:163:in `assert_no_difference'
/Users/edahl/Documents/GitHub/Zendesk-Data-Collector/test/jobs/incremental_ticket_job_test.rb:197:in `block in <class:IncrementalTicketJobTest>'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest/test.rb:91:in `block (2 levels) in run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest/test.rb:187:in `capture_exceptions'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest/test.rb:86:in `block in run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:397:in `time_it'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest/test.rb:85:in `run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/executor/test_helper.rb:5:in `block in run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/execution_wrapper.rb:104:in `perform'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/activesupport-8.1.2/lib/active_support/executor/test_helper.rb:5:in `run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:486:in `run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:473:in `block (2 levels) in run_suite'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:469:in `each'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:469:in `block in run_suite'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:511:in `on_signal'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:498:in `with_info_handler'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:468:in `run_suite'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/railties-8.1.2/lib/rails/test_unit/line_filtering.rb:30:in `run_suite'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:361:in `block in run_all_suites'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:361:in `map'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:361:in `run_all_suites'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:316:in `run'
/Users/edahl/.rvm/gems/ruby-3.3.4@ZD-DataCollector/gems/minitest-6.0.2/lib/minitest.rb:84:in `block in autorun'
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191075)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191076)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191077)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Rate limit (429) for resource incremental, waiting 1s (Retry-After: 1s, retry 1/3)
[IncrementalTicketJob] Retrying after 429 (attempt 1/3)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 1/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191078)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191079)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191080)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191081)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 0 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 0 total (created: 0, updated: 0, errors: 0)
[IncrementalTicketJob] Timestamp not updated (new: 1000, start: 1000)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191082)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 0 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 0 total (created: 0, updated: 0, errors: 0)
[IncrementalTicketJob] Timestamp not updated (new: 1000, start: 1000)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191083)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191084)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191085)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191086)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191087)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191088)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191089)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 3 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 3 total (created: 3, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191090)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191091)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 0, updated: 1, errors: 0)
[IncrementalTicketJob] Updated desk timestamp to 2000 (1969-12-31 19:33:20 -0500)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191092)
[IncrementalTicketJob] Last timestamp: 1000 (1969-12-31 19:16:40 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 0/3)
[IncrementalTicketJob] Rate limit (429) for resource incremental, waiting 1s (Retry-After: 1s, retry 1/3)
[IncrementalTicketJob] Retrying after 429 (attempt 1/3)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 1/3)
[IncrementalTicketJob] Rate limit (429) for resource incremental, waiting 2s (Retry-After: 1s, retry 2/3)
[IncrementalTicketJob] Retrying after 429 (attempt 2/3)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 2/3)
[IncrementalTicketJob] Rate limit (429) for resource incremental, waiting 3s (Retry-After: 1s, retry 3/3)
[IncrementalTicketJob] Retrying after 429 (attempt 3/3)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 1000, retry: 3/3)
[IncrementalTicketJob] Rate limit (429) for resource incremental, waiting 4s (Retry-After: 1s, retry 4/3)
[IncrementalTicketJob] Max retries reached after 429, exiting
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
.[IncrementalTicketJob] Starting for desk test.zendesk.com (ID: 980191093)
[IncrementalTicketJob] Last timestamp: 5000 (1969-12-31 20:23:20 -0500)
[IncrementalTicketJob] Fetching tickets from Zendesk API (start_time: 5000, retry: 0/3)
[IncrementalTicketJob] Received 1 ticket(s) and 0 user(s) from API
[IncrementalTicketJob] Completed processing: 1 total (created: 1, updated: 0, errors: 0)
[IncrementalTicketJob] Timestamp not updated (new: 3000, start: 5000)
[IncrementalTicketJob] Job completed for desk test.zendesk.com, queued flag reset
...............[QueueIncrementalTicketsJob] Checking for ready desks...
[QueueIncrementalTicketsJob] No ready desks found
.[QueueIncrementalTicketsJob] Checking for ready desks...
[QueueIncrementalTicketsJob] No ready desks found
.[QueueIncrementalTicketsJob] Incremental export cap reached (last minute), skipping this run
.[QueueIncrementalTicketsJob] Checking for ready desks...
[QueueIncrementalTicketsJob] Found 1 ready desk(s)
[QueueIncrementalTicketsJob] Queuing job for desk: ready.zendesk.com (ID: 980191098, last_timestamp: 1773978088)
[QueueIncrementalTicketsJob] Queued 1 job(s)
.[QueueIncrementalTicketsJob] Checking for ready desks...
[QueueIncrementalTicketsJob] Found 1 ready desk(s)
[QueueIncrementalTicketsJob] Queuing job for desk: ready-other.zendesk.com (ID: 980191101, last_timestamp: 1773978088)
[QueueIncrementalTicketsJob] Queued 1 job(s)
............

Finished in 7.764082s, 29.8812 runs/s, 88.8708 assertions/s.
232 runs, 690 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for RSpec to /Users/edahl/Documents/GitHub/Zendesk-Data-Collector/coverage.
Line Coverage: 78.86% (791 / 1003)
Branch Coverage: 58.81% (247 / 420) (all green).
